### PR TITLE
Should run genimmix rather than gencopy

### DIFF
--- a/configs/running-openjdk-genimmix-complete.yml
+++ b/configs/running-openjdk-genimmix-complete.yml
@@ -2,4 +2,4 @@ includes:
   - "./running-openjdk-base.yml"
 
 configs:
-  - "jdk-mmtk|gencopy|common_mmtk"
+  - "jdk-mmtk|genimmix|common_mmtk"


### PR DESCRIPTION
In a GenImmix config, the plan was mistakenly set to gencopy.