### PR TITLE
Fix typo in OpenJDK NoGC modifier

### DIFF
--- a/configs/running-openjdk-nogc-complete.yml
+++ b/configs/running-openjdk-nogc-complete.yml
@@ -2,4 +2,4 @@ includes:
   - "./running-openjdk-base.yml"
 
 configs:
-  - "jdk-mmtk|nogc|heap8|common_mmtk"
+  - "jdk-mmtk|nogc|heap8g|common_mmtk"


### PR DESCRIPTION
The OpenJDK NoGC config should use `heap8g`. It was typed wrong as `heap8`, which caused the run to fail.