### PR TITLE
Get plotlyjs from cdn (rather than inlined into the html)

### DIFF
--- a/scripts/history_report.py
+++ b/scripts/history_report.py
@@ -89,4 +89,4 @@ for plan in plans:
     # plot
     fig = plot.plot_history(build_info, runs, plan, benchmarks, from_date, to_date, "execution_times", baseline, config['notes'].copy())
     path = os.path.join(output_dir, "%s_%s_history.html" % (prefix, plan))
-    fig.write_html(path)
+    fig.write_html(path, include_plotlyjs='cdn')


### PR DESCRIPTION
This reduces the size of generated html (e.g. from 8MB down to 3MB for the largest HTML for OpenJDK).